### PR TITLE
Allow multiple controllers to run

### DIFF
--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -3,6 +3,7 @@ package ingress
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -49,7 +50,6 @@ func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder 
 	annotationParser := annotations.NewSuffixAnnotationParser(annotations.AnnotationPrefixIngress)
 	authConfigBuilder := ingress.NewDefaultAuthConfigBuilder(annotationParser)
 	enhancedBackendBuilder := ingress.NewDefaultEnhancedBackendBuilder(k8sClient, annotationParser, authConfigBuilder)
-	referenceIndexer := ingress.NewDefaultReferenceIndexer(enhancedBackendBuilder, authConfigBuilder, logger)
 	trackingProvider := tracking.NewDefaultProvider(ingressTagPrefix, config.ClusterName)
 	elbv2TaggingManager := elbv2deploy.NewDefaultTaggingManager(cloud.ELBV2(), cloud.VpcID(), config.FeatureGates, logger)
 	modelBuilder := ingress.NewDefaultModelBuilder(k8sClient, eventRecorder,
@@ -61,11 +61,11 @@ func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder 
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
 	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler,
 		config, ingressTagPrefix, logger)
-	classLoader := ingress.NewDefaultClassLoader(k8sClient)
-	classAnnotationMatcher := ingress.NewDefaultClassAnnotationMatcher(config.IngressConfig.IngressClass)
-	manageIngressesWithoutIngressClass := config.IngressConfig.IngressClass == ""
-	groupLoader := ingress.NewDefaultGroupLoader(k8sClient, eventRecorder, annotationParser, classLoader, classAnnotationMatcher, manageIngressesWithoutIngressClass)
+	ingressClass := config.IngressConfig.IngressClass
+	classLoader := ingress.NewClassLoaderWithIngressClass(k8sClient, ingressClass)
+	groupLoader := ingress.NewDefaultGroupLoader(k8sClient, eventRecorder, annotationParser, classLoader, ingressClass)
 	groupFinalizerManager := ingress.NewDefaultFinalizerManager(finalizerManager)
+	referenceIndexer := ingress.NewDefaultReferenceIndexer(enhancedBackendBuilder, authConfigBuilder, logger, classLoader)
 
 	return &groupReconciler{
 		k8sClient:         k8sClient,
@@ -81,6 +81,7 @@ func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder 
 		logger:                logger,
 
 		maxConcurrentReconciles: config.IngressConfig.MaxConcurrentReconciles,
+		ingressClass:            config.IngressConfig.IngressClass,
 	}
 }
 
@@ -100,6 +101,7 @@ type groupReconciler struct {
 	logger                logr.Logger
 
 	maxConcurrentReconciles int
+	ingressClass            string
 }
 
 // +kubebuilder:rbac:groups=elbv2.k8s.aws,resources=ingressclassparams,verbs=get;list;watch
@@ -121,7 +123,11 @@ func (r *groupReconciler) reconcile(ctx context.Context, req ctrl.Request) error
 	if err != nil {
 		return err
 	}
-
+	// if members and inactive members are both empty, then this ingress controller
+	// is not responsible for this ingress group
+	if len(ingGroup.Members) == 0 && len(ingGroup.InactiveMembers) == 0 {
+		return nil
+	}
 	if err := r.groupFinalizerManager.AddGroupFinalizer(ctx, ingGroupID, ingGroup.Members); err != nil {
 		r.recordIngressGroupEvent(ctx, ingGroup, corev1.EventTypeWarning, k8s.IngressEventReasonFailedAddFinalizer, fmt.Sprintf("Failed add finalizer due to %v", err))
 		return err

--- a/pkg/ingress/class_loader_test.go
+++ b/pkg/ingress/class_loader_test.go
@@ -2,6 +2,8 @@ package ingress
 
 import (
 	"context"
+	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
@@ -18,7 +20,6 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/webhook"
 	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-	"testing"
 )
 
 func Test_defaultClassLoader_Load(t *testing.T) {
@@ -500,7 +501,8 @@ func Test_defaultClassLoader_Load(t *testing.T) {
 			}
 
 			l := &defaultClassLoader{
-				client: k8sClient,
+				client:       k8sClient,
+				ingressClass: "alb",
 			}
 			got, err := l.Load(ctx, tt.args.ing)
 			if tt.wantErr != nil {

--- a/pkg/ingress/group_loader.go
+++ b/pkg/ingress/group_loader.go
@@ -3,16 +3,17 @@ package ingress
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
 	"github.com/pkg/errors"
 	networking "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
-	"regexp"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/k8s"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sort"
-	"strings"
 )
 
 const (
@@ -45,15 +46,14 @@ type GroupLoader interface {
 }
 
 // NewDefaultGroupLoader constructs new GroupLoader instance.
-func NewDefaultGroupLoader(client client.Client, eventRecorder record.EventRecorder, annotationParser annotations.Parser, classLoader ClassLoader, classAnnotationMatcher ClassAnnotationMatcher, manageIngressesWithoutIngressClass bool) *defaultGroupLoader {
+func NewDefaultGroupLoader(client client.Client, eventRecorder record.EventRecorder, annotationParser annotations.Parser, classLoader ClassLoader, ingressClass string) *defaultGroupLoader {
 	return &defaultGroupLoader{
 		client:           client,
 		eventRecorder:    eventRecorder,
 		annotationParser: annotationParser,
 
-		classLoader:                        classLoader,
-		classAnnotationMatcher:             classAnnotationMatcher,
-		manageIngressesWithoutIngressClass: manageIngressesWithoutIngressClass,
+		classLoader:  classLoader,
+		ingressClass: ingressClass,
 	}
 }
 
@@ -68,12 +68,8 @@ type defaultGroupLoader struct {
 	// classLoader loads IngressClass configurations for Ingress.
 	classLoader ClassLoader
 
-	// classAnnotationMatcher checks whether ingresses with "kubernetes.io/ingress.class" annotation should be managed.
-	classAnnotationMatcher ClassAnnotationMatcher
-
-	// manageIngressesWithoutIngressClass specifies whether ingresses without "kubernetes.io/ingress.class" annotation
-	// and "spec.ingressClassName" should be managed or not.
-	manageIngressesWithoutIngressClass bool
+	// ingress class this loader is for
+	ingressClass string
 }
 
 func (m *defaultGroupLoader) Load(ctx context.Context, groupID GroupID) (Group, error) {
@@ -87,9 +83,19 @@ func (m *defaultGroupLoader) Load(ctx context.Context, groupID GroupID) (Group, 
 	finalizer := buildGroupFinalizer(groupID)
 	for index := range ingList.Items {
 		ing := &ingList.Items[index]
+		// m.isGroupMember calls m.classifyIngress indirectly, but the cases of the ingress having the matching
+		// ingress class but not the matching group, and having the matching group but not the matching ingress
+		// class are conflated. There are some duplicate calls here but it seems tricky to untie.
+		classifiedIngress, isManagedIngress, err := m.isManagedIngress(ctx, ing)
+		if err != nil {
+			return Group{}, errors.Wrapf(err, "isManagedIngress - ingress: %v", k8s.NamespacedName(ing))
+		}
+		if !isManagedIngress {
+			continue
+		}
 		classifiedIngress, isGroupMember, err := m.isGroupMember(ctx, groupID, ing)
 		if err != nil {
-			return Group{}, errors.Wrapf(err, "ingress: %v", k8s.NamespacedName(ing))
+			return Group{}, errors.Wrapf(err, "isGroupMember - ingress: %v", k8s.NamespacedName(ing))
 		}
 		if isGroupMember {
 			members = append(members, classifiedIngress)
@@ -152,7 +158,7 @@ func (m *defaultGroupLoader) loadGroupIDIfAnyHelper(ctx context.Context, ing *ne
 	if !ing.DeletionTimestamp.IsZero() {
 		return ClassifiedIngress{}, nil, nil
 	}
-	classifiedIngress, matchesIngressClass, err := m.classifyIngress(ctx, ing)
+	classifiedIngress, matchesIngressClass, err := m.isManagedIngress(ctx, ing)
 	if err != nil {
 		return ClassifiedIngress{}, nil, err
 	}
@@ -167,20 +173,31 @@ func (m *defaultGroupLoader) loadGroupIDIfAnyHelper(ctx context.Context, ing *ne
 	return classifiedIngress, &groupID, nil
 }
 
-// classifyIngress will classify the Ingress resource and returns whether it should be managed by this controller, along with the ClassifiedIngress object.
-func (m *defaultGroupLoader) classifyIngress(ctx context.Context, ing *networking.Ingress) (ClassifiedIngress, bool, error) {
+// isManagedIngress will classify the Ingress resource and returns whether it should be managed by this controller, along with the ClassifiedIngress object.
+func (m *defaultGroupLoader) isManagedIngress(ctx context.Context, ing *networking.Ingress) (ClassifiedIngress, bool, error) {
+
+	classifiedIngress, ingressClass, err := m.classifyIngress(ctx, ing)
+
+	if err != nil {
+		return classifiedIngress, false, err
+	}
+	if classifiedIngress.IngClassConfig.IngClass != nil {
+		return classifiedIngress, classifiedIngress.IngClassConfig.IngClass.Spec.Controller == m.classLoader.ingressClassController(), nil
+	}
+	if ingressClass != "" {
+		return classifiedIngress, ingressClass == m.ingressClass, nil
+	}
+	return classifiedIngress, m.ingressClass == "", nil
+}
+
+// classifyIngress will classify the Ingress resource and returns the ClassifiedIngress object and ingress class.
+func (m *defaultGroupLoader) classifyIngress(ctx context.Context, ing *networking.Ingress) (ClassifiedIngress, string, error) {
 	// the "kubernetes.io/ingress.class" annotation takes higher priority than "ingressClassName" field
 	if ingClassAnnotation, exists := ing.Annotations[annotations.IngressClass]; exists {
-		if matchesIngressClass := m.classAnnotationMatcher.Matches(ingClassAnnotation); matchesIngressClass {
-			return ClassifiedIngress{
-				Ing:            ing,
-				IngClassConfig: ClassConfiguration{},
-			}, true, nil
-		}
 		return ClassifiedIngress{
 			Ing:            ing,
 			IngClassConfig: ClassConfiguration{},
-		}, false, nil
+		}, ingClassAnnotation, nil
 	}
 
 	if ing.Spec.IngressClassName != nil {
@@ -189,25 +206,18 @@ func (m *defaultGroupLoader) classifyIngress(ctx context.Context, ing *networkin
 			return ClassifiedIngress{
 				Ing:            ing,
 				IngClassConfig: ClassConfiguration{},
-			}, false, err
-		}
-
-		if matchesIngressClass := ingClassConfig.IngClass != nil && ingClassConfig.IngClass.Spec.Controller == ingressClassControllerALB; matchesIngressClass {
-			return ClassifiedIngress{
-				Ing:            ing,
-				IngClassConfig: ingClassConfig,
-			}, true, nil
+			}, "", err
 		}
 		return ClassifiedIngress{
 			Ing:            ing,
 			IngClassConfig: ingClassConfig,
-		}, false, nil
+		}, ingClassConfig.IngClass.Name, nil
 	}
 
 	return ClassifiedIngress{
 		Ing:            ing,
 		IngClassConfig: ClassConfiguration{},
-	}, m.manageIngressesWithoutIngressClass, nil
+	}, "", nil
 }
 
 // loadGroupID loads the groupID for classified Ingress.

--- a/pkg/ingress/group_loader_test.go
+++ b/pkg/ingress/group_loader_test.go
@@ -2,6 +2,9 @@ package ingress
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
@@ -16,8 +19,6 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/equality"
 	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
-	"time"
 )
 
 func Test_defaultGroupLoader_Load(t *testing.T) {
@@ -621,13 +622,11 @@ func Test_defaultGroupLoader_Load(t *testing.T) {
 
 			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
 			classLoader := NewDefaultClassLoader(k8sClient)
-			classAnnotationMatcher := NewDefaultClassAnnotationMatcher("alb")
 			m := &defaultGroupLoader{
-				client:                             k8sClient,
-				annotationParser:                   annotationParser,
-				classLoader:                        classLoader,
-				classAnnotationMatcher:             classAnnotationMatcher,
-				manageIngressesWithoutIngressClass: false,
+				client:           k8sClient,
+				annotationParser: annotationParser,
+				classLoader:      classLoader,
+				ingressClass:     "alb",
 			}
 			got, err := m.Load(context.Background(), tt.args.groupID)
 			if tt.wantErr != nil {
@@ -1297,13 +1296,11 @@ func Test_defaultGroupLoader_isGroupMember(t *testing.T) {
 
 			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
 			classLoader := NewDefaultClassLoader(k8sClient)
-			classAnnotationMatcher := NewDefaultClassAnnotationMatcher("alb")
 			m := &defaultGroupLoader{
-				client:                             k8sClient,
-				annotationParser:                   annotationParser,
-				classLoader:                        classLoader,
-				classAnnotationMatcher:             classAnnotationMatcher,
-				manageIngressesWithoutIngressClass: false,
+				client:           k8sClient,
+				annotationParser: annotationParser,
+				classLoader:      classLoader,
+				ingressClass:     "alb",
 			}
 
 			gotClassifiedIng, gotIsGroupMember, err := m.isGroupMember(context.Background(), tt.args.groupID, tt.args.ing)
@@ -1571,13 +1568,11 @@ func Test_defaultGroupLoader_loadGroupIDIfAnyHelper(t *testing.T) {
 
 			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
 			classLoader := NewDefaultClassLoader(k8sClient)
-			classAnnotationMatcher := NewDefaultClassAnnotationMatcher("alb")
 			m := &defaultGroupLoader{
-				client:                             k8sClient,
-				annotationParser:                   annotationParser,
-				classLoader:                        classLoader,
-				classAnnotationMatcher:             classAnnotationMatcher,
-				manageIngressesWithoutIngressClass: false,
+				client:           k8sClient,
+				annotationParser: annotationParser,
+				classLoader:      classLoader,
+				ingressClass:     "alb",
 			}
 			gotClassifiedIng, gotGroupID, err := m.loadGroupIDIfAnyHelper(context.Background(), tt.args.ing)
 			if tt.wantErr != nil {
@@ -1864,60 +1859,6 @@ func Test_defaultGroupLoader_classifyIngress(t *testing.T) {
 			},
 			wantErr: errors.New("invalid ingress class: ingressclasses.networking.k8s.io \"ing-class\" not found"),
 		},
-		{
-			name: "no class specified - manageIngressesWithoutIngressClass is set",
-			fields: fields{
-				ingressClass:                       "",
-				manageIngressesWithoutIngressClass: true,
-			},
-			args: args{
-				ing: &networking.Ingress{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace:   "ing-ns",
-						Name:        "ing-name",
-						Annotations: map[string]string{},
-					},
-				},
-			},
-			wantClassifiedIng: ClassifiedIngress{
-				Ing: &networking.Ingress{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace:   "ing-ns",
-						Name:        "ing-name",
-						Annotations: map[string]string{},
-					},
-				},
-				IngClassConfig: ClassConfiguration{},
-			},
-			wantIngressClassMatches: true,
-		},
-		{
-			name: "no class specified - manageIngressesWithoutIngressClass isn't set",
-			fields: fields{
-				ingressClass:                       "",
-				manageIngressesWithoutIngressClass: false,
-			},
-			args: args{
-				ing: &networking.Ingress{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace:   "ing-ns",
-						Name:        "ing-name",
-						Annotations: map[string]string{},
-					},
-				},
-			},
-			wantClassifiedIng: ClassifiedIngress{
-				Ing: &networking.Ingress{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace:   "ing-ns",
-						Name:        "ing-name",
-						Annotations: map[string]string{},
-					},
-				},
-				IngClassConfig: ClassConfiguration{},
-			},
-			wantIngressClassMatches: false,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1934,16 +1875,14 @@ func Test_defaultGroupLoader_classifyIngress(t *testing.T) {
 
 			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
 			classLoader := NewDefaultClassLoader(k8sClient)
-			classAnnotationMatcher := NewDefaultClassAnnotationMatcher(tt.fields.ingressClass)
 			m := &defaultGroupLoader{
-				client:                             k8sClient,
-				annotationParser:                   annotationParser,
-				classLoader:                        classLoader,
-				classAnnotationMatcher:             classAnnotationMatcher,
-				manageIngressesWithoutIngressClass: tt.fields.manageIngressesWithoutIngressClass,
+				client:           k8sClient,
+				annotationParser: annotationParser,
+				classLoader:      classLoader,
+				ingressClass:     "alb",
 			}
 
-			gotClassifiedIng, gotIngressClassMatches, err := m.classifyIngress(context.Background(), tt.args.ing)
+			gotClassifiedIng, gotIngressClassMatches, err := m.isManagedIngress(context.Background(), tt.args.ing)
 			if tt.wantErr != nil {
 				assert.EqualError(t, err, tt.wantErr.Error())
 			} else {
@@ -2132,6 +2071,7 @@ func Test_defaultGroupLoader_loadGroupID(t *testing.T) {
 			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
 			m := &defaultGroupLoader{
 				annotationParser: annotationParser,
+				ingressClass:     "alb",
 			}
 			got, err := m.loadGroupID(tt.args.classifiedIng)
 			if tt.wantErr != nil {
@@ -2309,7 +2249,9 @@ func Test_defaultGroupLoader_containsGroupFinalizer(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := &defaultGroupLoader{}
+			m := &defaultGroupLoader{
+				ingressClass: "alb",
+			}
 			got := m.containsGroupFinalizer(tt.args.groupID, tt.args.finalizer, tt.args.ing)
 			assert.Equal(t, tt.want, got)
 		})
@@ -2677,10 +2619,9 @@ func Test_defaultGroupLoader_sortGroupMembers(t *testing.T) {
 			client := mock_client.NewMockClient(ctrl)
 			annotationParser := annotations.NewSuffixAnnotationParser("alb.ingress.kubernetes.io")
 			m := &defaultGroupLoader{
-				client:                             client,
-				annotationParser:                   annotationParser,
-				classAnnotationMatcher:             NewDefaultClassAnnotationMatcher(ingressClassALB),
-				manageIngressesWithoutIngressClass: false,
+				client:           client,
+				annotationParser: annotationParser,
+				ingressClass:     "alb",
 			}
 			got, err := m.sortGroupMembers(tt.members)
 			assert.Equal(t, tt.want, got)

--- a/pkg/ingress/reference_indexer.go
+++ b/pkg/ingress/reference_indexer.go
@@ -35,12 +35,14 @@ type ReferenceIndexer interface {
 }
 
 // NewDefaultReferenceIndexer constructs new defaultReferenceIndexer.
-func NewDefaultReferenceIndexer(enhancedBackendBuilder EnhancedBackendBuilder, authConfigBuilder AuthConfigBuilder, logger logr.Logger) *defaultReferenceIndexer {
+func NewDefaultReferenceIndexer(enhancedBackendBuilder EnhancedBackendBuilder, authConfigBuilder AuthConfigBuilder, logger logr.Logger, classLoader ClassLoader) *defaultReferenceIndexer {
 	return &defaultReferenceIndexer{
 		enhancedBackendBuilder: enhancedBackendBuilder,
 		authConfigBuilder:      authConfigBuilder,
 		logger:                 logger,
+		classLoader:            classLoader,
 	}
+
 }
 
 var _ ReferenceIndexer = &defaultReferenceIndexer{}
@@ -50,6 +52,7 @@ type defaultReferenceIndexer struct {
 	enhancedBackendBuilder EnhancedBackendBuilder
 	authConfigBuilder      AuthConfigBuilder
 	logger                 logr.Logger
+	classLoader            ClassLoader
 }
 
 func (i *defaultReferenceIndexer) BuildServiceRefIndexes(ctx context.Context, ing *networking.Ingress) []string {
@@ -103,7 +106,7 @@ func (i *defaultReferenceIndexer) BuildIngressClassRefIndexes(_ context.Context,
 }
 
 func (i *defaultReferenceIndexer) BuildIngressClassParamsRefIndexes(_ context.Context, ingClass *networking.IngressClass) []string {
-	if ingClass.Spec.Controller != ingressClassControllerALB || ingClass.Spec.Parameters == nil {
+	if ingClass.Spec.Controller != i.classLoader.ingressClassController() || ingClass.Spec.Parameters == nil {
 		return nil
 	}
 	if ingClass.Spec.Parameters.APIGroup == nil ||

--- a/pkg/ingress/reference_indexer_test.go
+++ b/pkg/ingress/reference_indexer_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	testclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -504,12 +506,17 @@ func Test_defaultReferenceIndexer_BuildIngressClassParamsRefIndexes(t *testing.T
 			want: nil,
 		},
 	}
+	k8sSchema := runtime.NewScheme()
+	k8sClient := testclient.NewFakeClientWithScheme(k8sSchema)
+	classLoader := NewDefaultClassLoader(k8sClient)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+
 			i := &defaultReferenceIndexer{
 				enhancedBackendBuilder: tt.fields.enhancedBackendBuilder,
 				authConfigBuilder:      tt.fields.authConfigBuilder,
 				logger:                 tt.fields.logger,
+				classLoader:            classLoader,
 			}
 			got := i.BuildIngressClassParamsRefIndexes(context.Background(), tt.args.ingClass)
 			assert.Equal(t, tt.want, got)


### PR DESCRIPTION
### Issue

https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2185

### Description

Ensure that ingress controllers only manage ingress groups
that belong to that controller

This work removes some of the hardcoding of "alb" as a special
ingress name, particularly for ingressClasses that have
spec.controller set.

There is no impact at this stage on the shared node security group rules - this is the bare minimum as I see it to allow two ALB controllers to run without one of them removing the load balancer created by the other.

### Checklist
- [x] Added tests that cover your change (if possible)
- [ ] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
